### PR TITLE
Update to support Ghostscript 9.50+

### DIFF
--- a/lib/PostScript/Convert.pm
+++ b/lib/PostScript/Convert.pm
@@ -61,7 +61,7 @@ our %format = do {
   my @pdf_param  = (
     device      => 'pdfwrite',
     extension   => 'pdf',
-    format_code => [qw(-c .setpdfwrite)],
+    format_code => [-c => '3000000 setvmthreshold'],
     'format_param' # => VALUE
   );
 


### PR DESCRIPTION
Changed .setpdfwrite parameter to '3000000 setvmthreshold' for compatibility with Ghostscript 9.50+